### PR TITLE
Fix dotenv require

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,9 +1,5 @@
-const rfr = require('rfr');
-const dotenv = require('dotenv');
-const path = require('path');
 const Joi = require('joi');
-
-dotenv.config({ path: path.join(rfr.root, '.env') });
+require('dotenv').config();
 
 const envVarsSchema = Joi.object()
   .keys({


### PR DESCRIPTION
Since we're using default file name to store environment, we don't need
to provide its name.